### PR TITLE
Iterable - update kit docs

### DIFF
--- a/src/pages/developers/sdk/android/push-notifications/index.md
+++ b/src/pages/developers/sdk/android/push-notifications/index.md
@@ -217,6 +217,7 @@ The following Kit integrations can receive Push Notifications:
 * [Leanplum](/integrations/leanplum/event/#kit-integration)
 * [Localytics](/integrations/localytics/event/#push-notifications)
 * [Urban Airship](/integrations/urbanairship/event/#3-push-notifications)
+* [Iterable](/integrations/iterable/event/#iterable-kit-integration)
 
 Push Notifications from any of these partners will be displayed by the relevant kit instance. Note that you will need to provide your Server Key to the partner in order to send Push Notifications. See the docs for each integration for further details.
 

--- a/src/pages/developers/sdk/ios/push-notifications/index.md
+++ b/src/pages/developers/sdk/ios/push-notifications/index.md
@@ -55,6 +55,7 @@ The following Kit integrations can receive Push Notifications:
 * [Leanplum](/integrations/leanplum/event/#kit-integration)
 * [Localytics](/integrations/localytics/event/#push-notifications)
 * [Urban Airship](/integrations/urbanairship/event/#3-push-notifications)
+* [Iterable](/integrations/iterable/event/#iterable-kit-integration)
 
 Push Notifications from any of these partners will be displayed by the relevant kit instance. Note that you will need to upload your APNs Push SSL certificate to any providers you use for Push Notifications. See the docs for each integration for details.
 

--- a/src/pages/integrations/iterable/event/index.md
+++ b/src/pages/integrations/iterable/event/index.md
@@ -4,9 +4,9 @@ title: Event
 
 Iterable is a multi-channel growth marketing and user engagement platform that powers marketing, transactional, and lifecycle campaigns on email, web and mobile.  Iterable requires your application to be collecting email addresses.  This can be done by calling the `setUserIdentity` SDK method.
 
-There are two components to the Iterable event integration. All event forwarding is handled server-side by mParticle. To support Iterable's deeplinking capabilities, you must also include the Iterable Kit as part of your mParticle SDK installation. The embedded kit handles only deeplinking. Even if the kit is included, all event data is forwarded server-side.
+In order to support Iterable's features such as deeplinking, push notifications, in-app notifications, and more, you must also include the Iterable Kit as part of your mParticle SDK installation. See [Iterable Kit Integration](/integrations/iterable/event/#iterable-kit-integration) for the Kit's full feature list and installation instructions.
 
-The Iterable integration supports Android, iOS and Web data.
+The Iterable integration supports Android, iOS and Web data. All event data is forwarded server-side, even if the Iterable Kit is installed.
 
 ## Prerequisites
 
@@ -86,7 +86,7 @@ Iterable's client-side mParticle Kit enables the following features:
 - In-app messages
 - Mobile Inbox
 
-The Kit automatically handles user registration, push notifications, basic in-app messaging, and deep linking by mapping mParticle’s APIs to analogous Iterable APIs. To learn more about these API mappings, you can review the source code:
+The Kit automatically handles user registration, push notifications, basic in-app messaging, and deeplinking by mapping mParticle’s APIs to analogous Iterable APIs. To learn more about these API mappings, you can review the source code:
 - [iOS](https://github.com/mparticle-integrations/mparticle-apple-integration-iterable)
 - [Android](https://github.com/mparticle-integrations/mparticle-android-integration-iterable)
 
@@ -94,30 +94,24 @@ The Kit automatically handles user registration, push notifications, basic in-ap
 
 #### iOS
 
-To install Iterable's mParticle Kit for iOS:
+To install the Iterable Kit for iOS:
 - For CocoaPods, add the following dependency to your Podfile:
-:::code-selector-block
 ~~~ruby
 # Sample Podfile
 
 pod 'mParticle-iterable', '~> 7.15.10'
 ~~~
-:::
 
 - For Carthage, add the following dependency to your Cartfile:
-:::code-selector-block
 ~~~
 # Sample Cartfile
 
 github "Iterable/mparticle-apple-integration-iterable" ~> 7.15.10
 ~~~
-:::
-
 
 #### Android
 
-To install Iterable's mParticle Kit for Android, add the mParticle Kit dependency to your `build.gradle` file:
-:::code-selector-block
+To install the Iterable Kit for Android, add the Kit dependency to your `build.gradle` file:
 ~~~groovy
 // Sample build.gradle
 
@@ -125,11 +119,10 @@ dependencies {
     compile 'com.mparticle:android-iterable-kit:5.14.+'
 }
 ~~~
-:::
 
 To learn more about mParticle Kits and how to incorporate them when setting up mParticle's SDK, please review the mParticle Kit documentation:
 - [iOS](/developers/sdk/ios/kits)
-- [Android](developers/sdk/android/kits)
+- [Android](/developers/sdk/android/kits)
 
 #### Push Notifications
 

--- a/src/pages/integrations/iterable/event/index.md
+++ b/src/pages/integrations/iterable/event/index.md
@@ -129,11 +129,15 @@ dependencies {
 
 To learn more about mParticle Kits and how to incorporate them when setting up mParticle's SDK, please review the mParticle Kit documentation:
 - [iOS](/developers/sdk/ios/kits)
-- [Android](developers/sdk/android/kits/)
+- [Android](developers/sdk/android/kits)
 
-### Push notifications
+#### Push notifications
 
-The Iterable Kit is configured to automatically receive push registrations, display incoming push notifications, and track push opens. To setup these capabilities, you'll need to create a push integration in the Iterable UI and provide the name of the integration in the mParticle SDK configuration. See the [Create Push Integrations](/integrations/iterable/event/#3-create-push-integrations) section for more details.
+If your app includes the Iterable mParticle Kit, mParticle passes Iterable push notifications to the Kit for display. However, for this to work, you must first [set up a mobile app and push integration](/integrations/iterable/event/#3-create-push-integrations) (with associated push credentials) in Iterable.
+
+See mParticle's Push Notification documentation for more details:
+* [iOS](/developers/sdk/ios/push-notifications)
+* [Android](/developers/sdk/android/push-notifications)
 
 ## Configuration Settings
 

--- a/src/pages/integrations/iterable/event/index.md
+++ b/src/pages/integrations/iterable/event/index.md
@@ -86,7 +86,7 @@ Iterable's client-side mParticle Kit enables the following features:
 - In-app messages
 - Mobile Inbox
 
-The Kit automatically handles user registration, push notifications, client-side event tracking, basic in-app messaging, and deep linking by mapping mParticle’s APIs to analogous Iterable APIs. To learn more about these API mappings, you can review the source code:
+The Kit automatically handles user registration, push notifications, basic in-app messaging, and deep linking by mapping mParticle’s APIs to analogous Iterable APIs. To learn more about these API mappings, you can review the source code:
 - [iOS](https://github.com/mparticle-integrations/mparticle-apple-integration-iterable)
 - [Android](https://github.com/mparticle-integrations/mparticle-android-integration-iterable)
 

--- a/src/pages/integrations/iterable/event/index.md
+++ b/src/pages/integrations/iterable/event/index.md
@@ -82,7 +82,7 @@ Iterable's client-side mParticle Kit enables the following features:
 - Push notifications
 - Rich push notifications (media and action buttons)
 - Client-side event tracking
-- Deep linking
+- Deeplinking
 - In-app messages
 - Mobile Inbox
 
@@ -150,7 +150,7 @@ In-app notifications are handled automatically by the bundled Iterable SDK. For 
 
 #### Additional Configuration
 
-To handle deep links and custom actions from push notifications and in-app messages, you may need to define a urlDelegate (on iOS) or a urlHandler (on Android) on the `IterableConfig` object.
+To handle deeplinks and custom actions from push notifications and in-app messages, you may need to define a urlDelegate (on iOS) or a urlHandler (on Android) on the `IterableConfig` object.
 
 Whenever you need to pass custom configuration for the Iterable SDK, use the Kit API:
 

--- a/src/pages/integrations/iterable/event/index.md
+++ b/src/pages/integrations/iterable/event/index.md
@@ -131,13 +131,49 @@ To learn more about mParticle Kits and how to incorporate them when setting up m
 - [iOS](/developers/sdk/ios/kits)
 - [Android](developers/sdk/android/kits)
 
-#### Push notifications
+#### Push Notifications
 
 If your app includes the Iterable mParticle Kit, mParticle passes Iterable push notifications to the Kit for display. However, for this to work, you must first [set up a mobile app and push integration](/integrations/iterable/event/#3-create-push-integrations) (with associated push credentials) in Iterable.
 
 See mParticle's Push Notification documentation for more details:
 * [iOS](/developers/sdk/ios/push-notifications)
 * [Android](/developers/sdk/android/push-notifications)
+
+Additional setup:
+* For iOS, pass `UNUserNotificationCenterDelegate` calls to mParticle
+* For Android, add mParticle’s `InstanceIdService`, `MPReceiver`, `MPService` to AndroidManifest.xml
+
+#### Rich Push Notifications
+
+For rich push notification support on iOS, you need to set up a Notification Service Extension. Please refer to the Iterable support documentation on [Advanced iOS Push Notifications](https://support.iterable.com/hc/en-us/articles/360035451931-Advanced-iOS-Push-Notifications-#adding-a-push-notification-extension).
+
+On Android, rich push notifications are automatically supported with the Iterable Kit installed.
+
+#### In-App Notifications
+
+In-app notifications are handled automatically by the bundled Iterable SDK. For more details and customization options, please refer to the Iterable documentation:
+* [In-App Messages on iOS](https://support.iterable.com/hc/en-us/articles/360035536791)
+* [In-App Messages on Android](https://support.iterable.com/hc/en-us/articles/360035537231)
+
+#### Additional Configuration
+
+To handle deep links and custom actions from push notifications and in-app messages, you may need to define a urlDelegate (on iOS) or a urlHandler (on Android) on the `IterableConfig` object.
+
+Whenever you need to pass custom configuration for the Iterable SDK, use the Kit API:
+
+##### iOS
+~~~swift
+    let config = IterableConfig()
+    config.urlDelegate = self
+    MPKitIterable.setCustomConfig(config)
+~~~
+
+##### Android
+~~~java
+    IterableConfig.Builder configBuilder = new IterableConfig.Builder()
+        .setUrlHandler(this);
+    IterableKit.setCustomConfig(configBuilder.build());
+~~~
 
 ## Configuration Settings
 

--- a/src/pages/integrations/iterable/event/index.md
+++ b/src/pages/integrations/iterable/event/index.md
@@ -53,6 +53,7 @@ mParticle will forward the following identifiers to Iterable where available:
 * Apple Vendor ID (IDFV)
 * Google Advertising ID (GAID)
 * Android ID
+* mParticle ID
 
 ## Supported Event Types
 
@@ -76,28 +77,63 @@ The Iterable integration allows you to map a custom event to Iterable's [Update 
 
 ## Iterable Kit Integration
 
-mParticle also supports an Iterable Kit integration, which you can use to access Iterable's Deep Linking features. To use this integration, you need to include the Iterable kit in your installation of the mParticle SDK. The kit integration handles only Deep Linking. All other data is still sent server-to-server. The source code for each kit is available on Github:
+Iterable's client-side mParticle Kit enables the following features:
+- User registration with email, Customer ID or MPID
+- Push notifications
+- Rich push notifications (media and action buttons)
+- Client-side event tracking
+- Deep linking
+- In-app messages
+- Mobile Inbox
 
+The Kit automatically handles user registration, push notifications, client-side event tracking, basic in-app messaging, and deep linking by mapping mParticle’s APIs to analogous Iterable APIs. To learn more about these API mappings, you can review the source code:
 - [iOS](https://github.com/mparticle-integrations/mparticle-apple-integration-iterable)
 - [Android](https://github.com/mparticle-integrations/mparticle-android-integration-iterable)
 
-To add the Iterable Kit to your iOS or Android app, see the Cocoapods and Gradle examples below, and reference the [Apple SDK](/developers/sdk/ios/getting-started/) and [Android SDK](/developers/sdk/android/getting-started/) guides to read more about kits.
+### Adding the Kit to Your App
 
+#### iOS
+
+To install Iterable's mParticle Kit for iOS:
+- For CocoaPods, add the following dependency to your Podfile:
 :::code-selector-block
-~~~objectivec
-//Sample Podfile
-target '<Your Target>' do
-    pod 'mParticle-iterable', '~> 6'
-end
-~~~
+~~~ruby
+# Sample Podfile
 
-~~~java
-//Sample build.gradle
-dependencies {
-    compile 'com.mparticle:android-iterable-kit:4+'
-}
-~~~   
+pod 'mParticle-iterable', '~> 7.15.10'
+~~~
 :::
+
+- For Carthage, add the following dependency to your Cartfile:
+:::code-selector-block
+~~~
+# Sample Cartfile
+
+github "Iterable/mparticle-apple-integration-iterable" ~> 7.15.10
+~~~
+:::
+
+
+#### Android
+
+To install Iterable's mParticle Kit for Android, add the mParticle Kit dependency to your `build.gradle` file:
+:::code-selector-block
+~~~groovy
+// Sample build.gradle
+
+dependencies {
+    compile 'com.mparticle:android-iterable-kit:5.14.+'
+}
+~~~
+:::
+
+To learn more about mParticle Kits and how to incorporate them when setting up mParticle's SDK, please review the mParticle Kit documentation:
+- [iOS](/developers/sdk/ios/kits)
+- [Android](developers/sdk/android/kits/)
+
+### Push notifications
+
+The Iterable Kit is configured to automatically receive push registrations, display incoming push notifications, and track push opens. To setup these capabilities, you'll need to create a push integration in the Iterable UI and provide the name of the integration in the mParticle SDK configuration. See the [Create Push Integrations](/integrations/iterable/event/#3-create-push-integrations) section for more details.
 
 ## Configuration Settings
 


### PR DESCRIPTION
# Summary
- Update the Iterable Event page with documentation for the latest kit release
- Update the iOS and Android push notification pages to note that the Iterable kit supports push