### PR TITLE
Remove references to IDSync & any specific strategies being premium features.

### DIFF
--- a/src/pages/guides/idsync/profile-link-strategy/index.md
+++ b/src/pages/guides/idsync/profile-link-strategy/index.md
@@ -1,9 +1,7 @@
 ---
-title: Profile Link Strategy (Premium)
+title: Profile Link Strategy
 order: 7
 ---
-
-<aside>IDSync is a premium feature.  You may not have access to the tools and strategies documented in this section. Reach out to your Customer Success Manager for more information.</aside>
 
 | **Unique IDs** | **Login IDs** | **New Known User** | **On Logout** |
 | --- | --- | --- | --- |


### PR DESCRIPTION
remove references to IDSync/profile link strategy being a premium feature

# Summary

(Please provide a high level summary)
