### PR TITLE
Update index.md of Android Media SDK for custom

### DIFF
--- a/src/pages/developers/sdk/android/media/index.md
+++ b/src/pages/developers/sdk/android/media/index.md
@@ -204,6 +204,15 @@ val mediaSession = MediaSession.builder {
 }
 ```
 
+To log a custom event that does not correspond with the supported Media Session events, you can generate a completely custom event:
+
+```kotlin
+val mpEvent = mediaSession.buildMPEvent("Milestone", mapOf(
+    "type" to "95%"
+  ))
+MParticle.getInstance()?.logEvent(mpEvent)
+```
+
 ### Custom Event Schema
 
 The Media SDK will generate Custom events per the specification below.


### PR DESCRIPTION
Github shows how to log a completely custom event (Logging MediaEvents as Custom Events (MPEvent) to the MParticle Server, #2) but this does not exist in our docs.

# Summary

(Please provide a high level summary)
