### PR TITLE
Update index.md

### DIFF
--- a/src/pages/developers/linting/index.md
+++ b/src/pages/developers/linting/index.md
@@ -86,7 +86,7 @@ buildscript {
     }
     dependencies {
         ...
-        classpath 'com.mparticle:android-plugin:5.12.10'
+        classpath 'com.mparticle:android-plugin:5.14.9'
     }
 }
 ```


### PR DESCRIPTION
Updating mParticle's Android plugin version number - old version no longer exists, and throws a "not found" error when syncing Gradle.

# Summary

(Please provide a high level summary)
