### PR TITLE
Update index.md

### DIFF
--- a/src/pages/developers/sdk/android/media/index.md
+++ b/src/pages/developers/sdk/android/media/index.md
@@ -117,7 +117,7 @@ mediaSession.logMediaSessionStart()
 ```kotlin
 val options = Options(currentPlayheadPosition = 300)
 
-mediaSession.logPlayEvent(options)
+mediaSession.logPlay(options)
 ```
 
 3. (optional) Fire other events for user interaction, i.e. `pause`


### PR DESCRIPTION
use of mediaSession.logPlayEvent results in Unresolved reference: logPlayEvent. 

As noted in these docs above and below, the correct method is mediaSession.logPlay()

# Summary

(Please provide a high level summary)
