### PR TITLE
Update index.md

### DIFF
--- a/src/pages/developers/smartype/index.md
+++ b/src/pages/developers/smartype/index.md
@@ -143,7 +143,7 @@ The following command will generate an iOS "fat" framework containing all archit
 
 ```bash
 # With mvnx:
-mvnx com:mparticle:smartype-generator generate
+mvnx com.mparticle:smartype-generator generate
 
 # Or directly execute the pre-downloaded jar
 java -jar smartype.jar generate


### PR DESCRIPTION
line 146 has `mvnx com:mparticle:smartype-generator generate` - i believe it should be `mvnx com.mparticle:smartype-generator generate`

`com.` vs `com:`

# Summary

when running the command as is, the CLI will throw errors
