### PR TITLE
Update index.md - GIF Create Audience Tags

### DIFF
--- a/src/pages/guides/platform-guide/audiences/index.md
+++ b/src/pages/guides/platform-guide/audiences/index.md
@@ -445,6 +445,8 @@ There is no limit to the number of tags you can create, but each tag name is lim
 
 If you clone an audience, it's tags will be cloned, also.
 
+![AudienceTagOriginal.gif](https://s6.gifyu.com/images/AudienceTagOriginal.gif)
+
 ## Audience Faults
 
 If mParticle encounters errors forwarding an audience to an output, it will mark the connection as faulted. Audience Faults are visible from the Audience Manager, the Audience Connection screen, and the Audience tab on the **Setup > Outputs** page.


### PR DESCRIPTION
Updated index.md to show how audience tags are created within mParticle. It seems that the last picture ![BulkAudience3](/images/Platform-Update-Audience-Bulk-Audiences3-042019.png) is no longer valid when creating tags for audiences. Added a GIF to show how it can be done.

# Summary

(Please provide a high level summary)
