### PR TITLE
get all accounts to be more consistent

### DIFF
--- a/src/pages/developers/platform/index.md
+++ b/src/pages/developers/platform/index.md
@@ -169,7 +169,7 @@ curl \
 
 #### Get All Accounts
 
-`GET /accounts`
+`GET /accounts?accountId=1`
 
 
 ~~~bash


### PR DESCRIPTION
The other examples for GET requests contain the full string of the get request, whereas the one for Get All Accounts does not. I've added in the remainder of the string to avoid confusion

# Summary

(Please provide a high level summary)
