### PR TITLE
add clarity around datapoint api endpoint

### DIFF
--- a/src/pages/developers/platform/index.md
+++ b/src/pages/developers/platform/index.md
@@ -1569,7 +1569,7 @@ A DataPoint represents a unique data item that has been detected by our system. 
 
 `GET /apps/1/datapoints`
 
-Retrieves a list of DataPoints that exist for an App.
+Retrieves a list of DataPoints that exist for an App. The 1 is a placeholder for the Application Family ID 
 
 ~~~bash
 curl \


### PR DESCRIPTION
make it clear that the variable in the path stands for app family ID

# Summary

It was very unclear what the 1 here stands for. I'm adding in a line of clarity for anyone trying to use this endpoint in the future. 
