### PR TITLE
change plan_id type from integer to string

### DIFF
--- a/src/pages/developers/dataplanning-api/index.md
+++ b/src/pages/developers/dataplanning-api/index.md
@@ -392,7 +392,7 @@ const createdPlan = await dataPlanService.createDataPlan(plan)
 Name | Type | Description
 |---|---|---
 workspace_id | `integer` | The ID of the workspace containing your data plans
-plan_id | `integer` | The ID of the Data Plan to retrieve
+plan_id | `string` | The ID of the Data Plan to retrieve
 
 #### Example Request
 
@@ -424,7 +424,7 @@ The response will contain the entire Data Plan including all versions. [See abov
 Name | Type | Description
 |---|---|---
 workspace_id | `integer` | The ID of the workspace containing your data plans
-plan_id | `integer` | The ID of the Data Plan to retrieve
+plan_id | `string` | The ID of the Data Plan to retrieve
 
 #### Example Request
 
@@ -595,7 +595,7 @@ The response will contain the entire Data Plan Version including all versions. [
 Name | Type | Description
 |---|---|---
 workspace_id | `integer` | The ID of the workspace containing your data plans
-plan_id | `integer` | The ID of the Data Plan to retrieve
+plan_id | `string` | The ID of the Data Plan to retrieve
 version | `integer` | The version of the Data Plan to retrieve
 
 #### Example Request
@@ -633,7 +633,7 @@ The response will contain the entire Data Plan version. [See above](#example-res
 Name | Type | Description
 |---|---|---
 workspace_id | `integer` | The ID of the workspace containing your data plans
-plan_id | `integer` | The ID of the Data Plan to retrieve
+plan_id | `string` | The ID of the Data Plan to retrieve
 version | `integer` | The version of the Data Plan to retrieve
 
 #### Example Request


### PR DESCRIPTION
the docs incorrectly state that plan_id is an integer, when in fact, it's a string. This makes for a very confusing UX

# Summary

While testing the data planning api, i learned that plan_id was a string, which was inconsistent with what these docs say. I checked with kevin and confirmed that it should be a string rather than an integer, as displayed in the UI. 