### PR TITLE
Update support for commerce event mappings

### DIFF
--- a/src/pages/integrations/google-analytics-4/event/index.md
+++ b/src/pages/integrations/google-analytics-4/event/index.md
@@ -264,9 +264,9 @@ mParticle automatically maps commerce events to Firebase event names based on th
 | `remove_from_cart` | `Product.REMOVE_FROM_CART` | `MPCommerceEventActionRemoveFromCart` |  `ProductActionType.RemoveFromCart` |
 | `select_item` | `Product.CLICK` | `MPCommerceEventActionClick` | `ProductActionType.Click` | 
 | `view_item` | `Product.DETAIL` | `MPCommerceEventActionViewDetail` | `ProductActionType.ViewDetail` | 
-| `view_item_list` | Support Coming Soon | Support Coming Soon | `ProductActionType.Impression` | 
-| `select_promotion` | Support Coming Soon | Support Coming Soon | `PromotionType.PromotionClick` | Does not support items
-| `view_promotion` | Support Coming Soon | Support Coming Soon | `PromotionType.PromotionView` | Does not support items
+| `view_item_list` | `Impression` | `MPCommerceEventKindImpression` | `ProductActionType.Impression` | 
+| `select_promotion` | `Promotion.CLICK` | `MPPromotionActionClick` | `PromotionType.PromotionClick` | Does not support items
+| `view_promotion` | `Promotion.VIEW` | `MPPromotionActionView` | `PromotionType.PromotionView` | Does not support items
 
 ## Custom Flags
 Custom flags are used to send partner-specific data points:


### PR DESCRIPTION
Per slack thread: https://mparticle.slack.com/archives/C0353TVNV1U/p1661354701146569

GA4 events view_item_list, select_promotion, and view_promotion were listed as "Support Coming Soon" but this was already implemented in both kits and S2S

## Summary
- {provide a thorough description of the changes}

## Testing Plan
- {explain how this has been tested, and what additional testing should be done}

## Reference Issue
- Closes https://go.mparticle.com/work/REPLACEME