### PR TITLE
Remove "view_cart" custom flag

### DIFF
--- a/src/pages/integrations/google-analytics-4/event/index.md
+++ b/src/pages/integrations/google-analytics-4/event/index.md
@@ -272,7 +272,7 @@ Custom flags are used to send partner-specific data points:
 
 | Custom Flag |  Data Type |  Platform | Description |
 | --- | --- | --- | --- |
-| `GA4.CommerceEventType` | `string` | All | One of `add_shipping_info`, `add_payment_info`, or `view_cart`. Constants are available on Android and iOS.
+| `GA4.CommerceEventType` | `string` | All | One of `add_shipping_info` or `add_payment_info`. Constants are available on Android and iOS.
 | `GA4.PaymentType` | `string` | All | To be used with `GA4.CommerceEventType` of `add_payment_info`. Constants are available on Android and iOS.
 | `GA4.ShippingTier` | `string` | All | To be used with `GA4.CommerceEventType` of `add_shipping_info`. Constants are available on Android and iOS.
 | `GA4.Google.Title` | `string` | Web | The title of the page


### PR DESCRIPTION
this is not currently a supported custom flag and does not map to an event.

## Summary
Remove "view_cart" custom flag 

## Testing Plan
none

## Reference Issue
- Closes https://go.mparticle.com/work/REPLACEME