### PR TITLE
added view_cart event mapping information

### DIFF
--- a/src/pages/integrations/google-analytics-4/event/index.md
+++ b/src/pages/integrations/google-analytics-4/event/index.md
@@ -255,6 +255,7 @@ mParticle automatically maps commerce events to Firebase event names based on th
 | -------------  | ------------- | ------------- | ------------- | ------------- |
 | `add_payment_info` | `Product.CHECKOUT_OPTION` | `MPCommerceEventActionCheckoutOptions` | `ProductActionType.CheckoutOption` | Requires custom flags (See below for more details)
 | `add_shipping_info` | `Product.CHECKOUT_OPTION` | `MPCommerceEventActionCheckoutOptions` | `ProductActionType.CheckoutOption` | Requires custom flags (See below for more details)
+| `view_cart` | Support Coming Soon | Support Coming Soon | `ProductActionType.Unknown` | Requires custom flags (See below for more details)
 | `add_to_cart` | `Product.ADD_TO_CART` | `MPCommerceEventActionAddToCart` | `ProductActionType.AddToCart` | 
 | `add_to_wishlist` | `Product.ADD_TO_WISHLIST` | `MPCommerceEventActionAddToWishList` | `ProductActionType.AddToWishlist` | 
 | `begin_checkout` | `Product.CHECKOUT` | `MPCommerceEventActionCheckout` | `ProductActionType.Checkout` | 
@@ -272,7 +273,7 @@ Custom flags are used to send partner-specific data points:
 
 | Custom Flag |  Data Type |  Platform | Description |
 | --- | --- | --- | --- |
-| `GA4.CommerceEventType` | `string` | All | One of `add_shipping_info` or `add_payment_info`. Constants are available on Android and iOS.
+| `GA4.CommerceEventType` | `string` | All | One of `add_shipping_info` or `add_payment_info` or `view_cart`. Constants are available on Android and iOS.
 | `GA4.PaymentType` | `string` | All | To be used with `GA4.CommerceEventType` of `add_payment_info`. Constants are available on Android and iOS.
 | `GA4.ShippingTier` | `string` | All | To be used with `GA4.CommerceEventType` of `add_shipping_info`. Constants are available on Android and iOS.
 | `GA4.Title` | `string` | Web | The title of the page


### PR DESCRIPTION
according to commerce-handler.js#L39-L41 in https://github.com/mparticle-integrations/mparticle-javascript-integration-google-analytics-4 we support the view_cart event via custom flags and unknown product action event.

## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - {provide a thorough description of the changes}

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
